### PR TITLE
Deprecate two methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ String secret = OTP.randomBase32(20);
 
 // Generate a Time-based OTP from the secret, using Unix-time
 // rounded down to the nearest 30 seconds.
-String code = OTP.create(secret, OTP.timeInHex(), 6, Type.TOTP);
+String hexTime = OTP.timeInHex(System.currentTimeMillis());
+String code = OTP.create(secret, hexTime, 6, Type.TOTP);
 ```
 
 Show the user the QR Code <sup>1</sup>

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'com.amdelamar'
-version = '1.2.0'
+version = '1.2.2'
 description = 'OTP (One Time Password) utility in Java. To enable two-factor authentication (2FA) using HMAC-based) or Time-based algorithms.'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/docs/index.html
+++ b/docs/index.html
@@ -107,7 +107,8 @@ String secret = OTP.randomBase32(20);
 
 // Generate a Time-based OTP from the secret, using Unix-time
 // rounded down to the nearest 30 seconds.
-String code = OTP.create(secret, OTP.timeInHex(), 6, Type.TOTP);</code></pre>
+String hexTime = OTP.timeInHex(System.currentTimeMillis());
+String code = OTP.create(secret, hexTime, 6, Type.TOTP);</code></pre>
             <p>
             Show User QR Code<sup>1</sup><br>
             Easiest way to do this is through Goolge APIs, but I plan to add a <code>generateImage()</code> function soon.</p>

--- a/src/main/java/com/amdelamar/jotp/OTP.java
+++ b/src/main/java/com/amdelamar/jotp/OTP.java
@@ -36,6 +36,7 @@ public final class OTP {
      *            default 20
      * @return secure random string
      */
+    @Deprecated
     public static String random(String characters, int length) {
         int len = length < 1 ? BYTES : length;
         SecureRandom random = new SecureRandom();
@@ -68,6 +69,7 @@ public final class OTP {
      * @return String Hex time
      * @throws IOException when generating Unix time
      */
+    @Deprecated
     public static String timeInHex() throws IOException {
         return timeInHex(System.currentTimeMillis());
     }
@@ -131,7 +133,7 @@ public final class OTP {
      * Returns true if the code is valid for the Hmac-based or Time-based OTP of the secret.
      *
      * For Hmac-based the 'base' is a counter, like 1,2,3. For Time-based the 'base' is Unix-time
-     * rounded down to the nearest 30 seconds via "getTimeInHex()"
+     * rounded down to the nearest 30 seconds.
      *
      * @param secret
      *            Shhhhh. (Base32)

--- a/src/test/java/com/amdelamar/jotp/OTPTest.java
+++ b/src/test/java/com/amdelamar/jotp/OTPTest.java
@@ -24,24 +24,17 @@ public class OTPTest {
     public void randomTests() {
 
         assertNotNull(OTP.randomBase32(0));
-        assertNotNull(OTP.random("123", 0));
 
         String r1 = OTP.randomBase32(20);
         String r2 = OTP.randomBase32(20);
         assertNotEquals(r1, r2);
-
-        assertNotNull(OTP.random("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567", 12));
-
-        String r3 = OTP.random("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567", 12);
-        String r4 = OTP.random("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567", 12);
-        assertNotEquals(r3, r4);
     }
 
     @Test
     public void timeTests() throws IllegalArgumentException, IOException, InterruptedException {
 
-        String t1 = OTP.timeInHex();
-        String t2 = OTP.timeInHex();
+        String t1 = OTP.timeInHex(System.currentTimeMillis());
+        String t2 = OTP.timeInHex(System.currentTimeMillis());
 
         // wait a half second
         Thread.sleep(500);
@@ -54,12 +47,6 @@ public class OTPTest {
 
     @Test
     public void encodeTests() {
-
-        // run 5 tests
-        for (int i = 0; i < 5; i++) {
-            assertNotNull(OTP.random("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567", 12));
-        }
-
         // run 5 tests
         for (int i = 0; i < 5; i++) {
             assertNotNull(OTP.randomBase32(OTP.BYTES));
@@ -86,7 +73,7 @@ public class OTPTest {
     public void badSecretTests() {
         try {
             // bad secret
-            OTP.create(null, OTP.timeInHex(), 6, Type.TOTP);
+            OTP.create(null, OTP.timeInHex(System.currentTimeMillis()), 6, Type.TOTP);
             fail("null secret not detected");
         } catch (Exception e) {
             // good catch
@@ -94,7 +81,7 @@ public class OTPTest {
 
         try {
             // empty secret
-            OTP.create("", OTP.timeInHex(), 6, Type.TOTP);
+            OTP.create("", OTP.timeInHex(System.currentTimeMillis()), 6, Type.TOTP);
             fail("empty secret not detected");
         } catch (Exception e) {
             // good catch
@@ -102,7 +89,7 @@ public class OTPTest {
 
         try {
             // short secret
-            OTP.create("123", OTP.timeInHex()
+            OTP.create("123", OTP.timeInHex(System.currentTimeMillis())
                     .substring(3), 6, Type.TOTP);
             // should be ok
         } catch (Exception e) {
@@ -114,7 +101,7 @@ public class OTPTest {
     @Test
     public void uppercaseSecretTests() {
         try {
-            String time = OTP.timeInHex();
+            String time = OTP.timeInHex(System.currentTimeMillis());
             String t1 = OTP.create("MFRGGZDFMZTWQ2LK", time, 6, Type.TOTP);
             String t2 = OTP.create("mfrggzdfmztwq2lk", time, 6, Type.TOTP);
             assertEquals(t1, t2);
@@ -148,7 +135,7 @@ public class OTPTest {
     public void badDigitTests() {
         try {
             // bad digits
-            OTP.create("123", OTP.timeInHex(), 0, Type.TOTP);
+            OTP.create("123", OTP.timeInHex(System.currentTimeMillis()), 0, Type.TOTP);
             fail("zero digits not detected");
         } catch (Exception e) {
             // good catch
@@ -156,7 +143,7 @@ public class OTPTest {
 
         try {
             // bad type
-            OTP.create("123", OTP.timeInHex(), 6, null);
+            OTP.create("123", OTP.timeInHex(System.currentTimeMillis()), 6, null);
             fail("null type not detected");
         } catch (Exception e) {
             // good catch
@@ -167,7 +154,7 @@ public class OTPTest {
     public void badCodeTests() {
         try {
             // null verify code
-            OTP.verify("123", OTP.timeInHex(), null, 6, Type.TOTP);
+            OTP.verify("123", OTP.timeInHex(System.currentTimeMillis()), null, 6, Type.TOTP);
             fail("null code not detected");
         } catch (Exception e) {
             // good catch
@@ -175,7 +162,7 @@ public class OTPTest {
 
         try {
             // empty verify code
-            OTP.verify("123", OTP.timeInHex(), "", 6, Type.TOTP);
+            OTP.verify("123", OTP.timeInHex(System.currentTimeMillis()), "", 6, Type.TOTP);
             fail("empty code not detected");
         } catch (Exception e) {
             // good catch
@@ -183,7 +170,7 @@ public class OTPTest {
 
         try {
             // bad verify code length
-            boolean flag = OTP.verify("123", OTP.timeInHex(), "12345", 6, Type.TOTP);
+            boolean flag = OTP.verify("123", OTP.timeInHex(System.currentTimeMillis()), "12345", 6, Type.TOTP);
             assertFalse(flag);
         } catch (Exception e) {
             fail("bad code length not detected");

--- a/src/test/java/com/amdelamar/jotp/type/TOTPTest.java
+++ b/src/test/java/com/amdelamar/jotp/type/TOTPTest.java
@@ -39,23 +39,23 @@ public class TOTPTest {
         // run 5 tests
         for (int i = 0; i < 5; i++) {
             String secret = OTP.randomBase32(OTP.BYTES);
-            String code1 = OTP.create(secret, OTP.timeInHex(), 6, Type.TOTP);
+            String code1 = OTP.create(secret, OTP.timeInHex(System.currentTimeMillis()), 6, Type.TOTP);
 
             // 30 sec window, so wait just a second
             // If its beyond 30sec since the first OTP,
             // then we will get a different base value.
             Thread.sleep(500);
 
-            String code2 = OTP.create(secret, OTP.timeInHex(), 6, Type.TOTP);
+            String code2 = OTP.create(secret, OTP.timeInHex(System.currentTimeMillis()), 6, Type.TOTP);
             assertEquals(code1, code2);
-            assertTrue(OTP.verify(secret, OTP.timeInHex(), code2, 6, Type.TOTP));
+            assertTrue(OTP.verify(secret, OTP.timeInHex(System.currentTimeMillis()), code2, 6, Type.TOTP));
         }
     }
     
     @Test
     public void padLeft() throws InvalidKeyException, IllegalArgumentException, NoSuchAlgorithmException, IOException {
         String secret = OTP.randomBase32(OTP.BYTES);
-        String code1 = OTP.create(secret, OTP.timeInHex(), 16, Type.TOTP);
+        String code1 = OTP.create(secret, OTP.timeInHex(System.currentTimeMillis()), 16, Type.TOTP);
         
         // code padded with 00's until it meets length desired
         // e.g. 0000001868692305


### PR DESCRIPTION
timeInHex() and random(), as both are not critical to keep anyway.

Will remove them in the next minor release. #13