### PR TITLE
Allow custom periods in seconds in timeInHex

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'com.amdelamar'
-version = '1.2.2'
+version = '1.3.0'
 description = 'OTP (One Time Password) utility in Java. To enable two-factor authentication (2FA) using HMAC-based) or Time-based algorithms.'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/com/amdelamar/jotp/OTP.java
+++ b/src/main/java/com/amdelamar/jotp/OTP.java
@@ -81,7 +81,23 @@ public final class OTP {
      * @throws IOException when generating Unix time
      */
     public static String timeInHex(long timeInMillis) throws IOException {
-        final long time = (long) Math.floor(Math.round(((double) timeInMillis) / 1000.0) / 30d);
+        return timeInHex(timeInMillis, 30);
+    }
+
+    /**
+     * A method to get a Unix Time converted to Hexadecimal using a token period.
+     * @param timeInMillis long (like <code>System.currentTimeMillis()</code>)
+     * @param periodInSec int seconds period for the time to be rounded down to
+     * @return String Hex time
+     * @throws IOException
+     */
+    public static String timeInHex(long timeInMillis, int periodInSec) throws IOException {
+        double period = 1d;
+        if (periodInSec > 1) {
+            // ensure period is 1 or greater value
+            period = periodInSec;
+        }
+        final long time = (long) Math.floor(Math.round(((double) timeInMillis) / 1000d) / period);
         final byte[] longBytes = ByteBuffer.allocate(Long.SIZE / Byte.SIZE)
                 .putLong(time)
                 .array();


### PR DESCRIPTION
Instead of forcing 30s default periods, this
change allows users to specify their own
period value using timeInHex(time, period).

Period must be positive non-zero integer.

Fixes #14